### PR TITLE
Add zoom hover effect on project images

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -161,6 +161,8 @@ a {
 .work-item-right {
     display: flex;
     align-items: center;
+    overflow: hidden;
+    border-radius: 1rem;
     /*background-image: url("/images/dch_bg.png");*/
     /*background-size: contain;*/
     /*background-repeat: no-repeat;*/
@@ -171,6 +173,12 @@ a {
     height: auto;
     width: 100%;
     display: block;
+    transition: transform 0.3s ease;
+    border-radius: inherit;
+}
+
+.work-item:hover .work-item-right-image {
+    transform: scale(1.05);
 }
 
 .work-item-tags {


### PR DESCRIPTION
## Summary
- allow images inside project cards to scale up on hover
- keep rounded corners intact while zoomed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684678c3c95483288659ccd4f901131d